### PR TITLE
Adding type declaration for component

### DIFF
--- a/lib/module.d.ts
+++ b/lib/module.d.ts
@@ -1,0 +1,9 @@
+declare module 'react-tagify' {
+  interface IProps {
+    colors?: string;
+    tagClicked?: (tag: string) => void;
+  }
+
+  class ReactTagify extends React.Component<IProps, any> {}
+  export { ReactTagify }; 
+}

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
     "version": "0.0.7",
     "description": "📢 A Powerful Pure React Component To Hashtags and Mentions To You'r React App",
     "main": "./lib/ReactTagify.js",
+    "typings": "./lib/module.d.ts",
     "author": "Sina Farhadi",
     "license": "MIT",
     "scripts": {


### PR DESCRIPTION
First of off, nice work with this component :+1: 

With this PR, the following typing issue when using react-tagify with TypeScript will be fixed:
![](https://silind-s3.s3.eu-west-2.amazonaws.com/random/typing-example.png)

Furthermore, keeping a declaration file also gives most IDE's the ability to provide hints about which props the component expects:
![](https://silind-s3.s3.eu-west-2.amazonaws.com/random/example-js.gif)

In TypeScript it gets even better - here you will have linting associated with the props as well:
![](https://silind-s3.s3.eu-west-2.amazonaws.com/random/example-ts-1.gif)

![](https://silind-s3.s3.eu-west-2.amazonaws.com/random/example-ts-2.gif)